### PR TITLE
[PAYG-524] Deprecate repo in favour of truelayer-signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Payments API Webhook Examples
 
+## ⚠️ Deprecated ⚠️
+> **`X-Tl-Signature` headers have been deprecated in favour of "v2" `Tl-Signature` full request signature headers.**
+>
+> **Go to https://github.com/TrueLayer/truelayer-signing for multi-language signing libraries & examples.**
+
 This repository contains code samples for verifying webhook signatures that originate from the TrueLayer Payments API.
 
 [Payments API v1](https://docs.truelayer.com/#payments-api-v1) and [Payments API v2](https://docs.truelayer.com/#payments-api-v2) use different signing methods; the relevant code samples for each can be found in the v1 and v2 folders, respectively.


### PR DESCRIPTION
`X-Tl-Signature` headers have been deprecated in favour of "v2" `Tl-Signature` full request signature headers.

Clients should go to https://github.com/TrueLayer/truelayer-signing for multi-language signing libraries & examples. And we should make improvements there to benefit a wider base in a more maintainable way.